### PR TITLE
Parse comma-separated values and expect the 'filter' param key

### DIFF
--- a/lib/has_scope.rb
+++ b/lib/has_scope.rb
@@ -106,9 +106,9 @@ module HasScope
   #     end
   #   end
   #
-  def apply_scopes(target, hash=params)
+  def apply_scopes(target, hash=params[:filter])
     scopes_configuration.each do |scope, options|
-      next unless apply_scope_to_action?(options)
+      next unless apply_scope_to_action?(options) && !hash.nil?
       key = options[:as]
 
       if hash.key?(key)
@@ -134,6 +134,7 @@ module HasScope
 
   # Set the real value for the current scope if type check.
   def parse_value(type, key, value) #:nodoc:
+    value = value.split(',') if type == :array && value.class == String
     klasses, parser = ALLOWED_TYPES[type]
     if klasses.any? { |klass| value.is_a?(klass) }
       parser ? parser.call(value) : value


### PR DESCRIPTION
This change parses comma-separated values for filter params, so that multiple values can be sent in a request like this: `?filter[location_name]=loc1,loc2`
rather than like this:`?filter[location_name][]=loc1,filter[location_name][]=loc2`

Expects the `filter` param by default.

Reference: https://jsonapi.org/recommendations/#filtering

